### PR TITLE
feat: define source-of-truth event protocol from agent layer

### DIFF
--- a/cmd/imclaw-cli/main.go
+++ b/cmd/imclaw-cli/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/smallnest/imclaw/internal/agent"
 	"github.com/smallnest/imclaw/internal/event"
 	flag "github.com/spf13/pflag"
 )
@@ -201,8 +202,8 @@ type JSONRPCError struct {
 	Message string `json:"message"`
 }
 
-// StreamEvent is an alias for event.Event
-type StreamEvent = event.Event
+// StreamEvent is an alias for agent.Event
+type StreamEvent = agent.Event
 
 // Client is the IMClaw client
 type Client struct {
@@ -677,10 +678,13 @@ func notificationMatchesRequest(params map[string]interface{}, reqID string) boo
 }
 
 // parseEventParams parses event parameters from JSON-RPC notification params.
-func parseEventParams(params map[string]interface{}) event.Event {
-	evt := event.Event{}
+func parseEventParams(params map[string]interface{}) agent.Event {
+	evt := agent.Event{}
+	if v, ok := params["version"].(string); ok {
+		evt.Version = v
+	}
 	if t, ok := params["type"].(string); ok {
-		evt.Type = event.Type(t)
+		evt.Type = agent.EventType(t)
 	}
 	if c, ok := params["content"].(string); ok {
 		evt.Content = c
@@ -697,8 +701,8 @@ func parseEventParams(params map[string]interface{}) event.Event {
 	return evt
 }
 
-func writeStructuredEvent(stdout, stderr io.Writer, evt event.Event) {
-	if evt.Type == event.TypeError {
+func writeStructuredEvent(stdout, stderr io.Writer, evt agent.Event) {
+	if evt.Type == agent.TypeError {
 		fmt.Fprintf(stderr, "[error] %s\n", evt.Content)
 		return
 	}

--- a/cmd/imclaw-cli/main_test.go
+++ b/cmd/imclaw-cli/main_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/smallnest/imclaw/internal/event"
+	"github.com/smallnest/imclaw/internal/agent"
 	flag "github.com/spf13/pflag"
 )
 
@@ -83,12 +83,13 @@ func TestWriteParsedMessageOutputsJSONLine(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
-	writeStructuredEvent(&stdout, &stderr, event.Event{
-		Type:    event.TypeThinking,
+	writeStructuredEvent(&stdout, &stderr, agent.Event{
+		Version: agent.EventProtocolVersion,
+		Type:    agent.TypeThinkingDelta,
 		Content: "hello",
 	})
 
-	if got := stdout.String(); got != "{\"type\":\"thinking\",\"content\":\"hello\"}\n" {
+	if got := stdout.String(); got != "{\"version\":\"v1\",\"type\":\"thinking_delta\",\"content\":\"hello\"}\n" {
 		t.Fatalf("unexpected parsed message output: %q", got)
 	}
 	if got := stderr.String(); got != "" {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,14 +12,47 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/creack/pty"
 )
 
-// StreamChunk represents a chunk of streaming output
+// StreamChunk represents a chunk of streaming output.
 type StreamChunk struct {
-	Type    string `json:"type"`    // "content", "error", "done"
-	Content string `json:"content"` // The content of the chunk
+	Type    string  `json:"type"`             // "content", "error", "done"
+	Content string  `json:"content"`          // The content of the chunk
+	Events  []Event `json:"events,omitempty"` // Native agent events for this chunk
+}
+
+// EventProtocolVersion identifies the agent event schema version.
+const EventProtocolVersion = "v1"
+
+// EventType identifies the type of an agent-native stream event.
+type EventType string
+
+const (
+	TypeThinkingStart EventType = "thinking_start"
+	TypeThinkingDelta EventType = "thinking_delta"
+	TypeThinkingEnd   EventType = "thinking_end"
+	TypeToolStart     EventType = "tool_start"
+	TypeToolInput     EventType = "tool_input"
+	TypeToolOutput    EventType = "tool_output"
+	TypeToolEnd       EventType = "tool_end"
+	TypeOutputDelta   EventType = "output_delta"
+	TypeOutputFinal   EventType = "output_final"
+	TypeError         EventType = "error"
+	TypeDone          EventType = "done"
+)
+
+// Event is the source-of-truth agent event forwarded to gateway clients.
+type Event struct {
+	Version string    `json:"version"`
+	Type    EventType `json:"type"`
+	Content string    `json:"content,omitempty"`
+	Name    string    `json:"name,omitempty"`
+	Input   string    `json:"input,omitempty"`
+	Output  string    `json:"output,omitempty"`
 }
 
 // Agent represents an AI agent
@@ -576,6 +610,7 @@ func (a *ACPXAgent) runCommandStream(ctx context.Context, timeout int, args ...s
 		// Read stdout in raw chunks so output can stream even without newlines.
 		reader := bufio.NewReader(ptmx)
 		var accumulatedContent strings.Builder
+		parser := NewProtocolParser()
 		buf := make([]byte, 1024)
 
 		for {
@@ -583,9 +618,10 @@ func (a *ACPXAgent) runCommandStream(ctx context.Context, timeout int, args ...s
 			if n > 0 {
 				chunk := string(buf[:n])
 				accumulatedContent.WriteString(chunk)
+				events := parser.Feed(chunk)
 
 				select {
-				case outputCh <- StreamChunk{Type: "content", Content: chunk}:
+				case outputCh <- StreamChunk{Type: "content", Content: chunk, Events: events}:
 				case <-ctx.Done():
 					return
 				}
@@ -601,16 +637,19 @@ func (a *ACPXAgent) runCommandStream(ctx context.Context, timeout int, args ...s
 
 		// Wait for command to complete
 		waitErr := cmd.Wait()
+		flushEvents := parser.Flush()
 
 		// Send done or error (with context check to avoid deadlock)
 		if waitErr != nil {
+			events := append(flushEvents, Event{Version: EventProtocolVersion, Type: TypeError, Content: waitErr.Error()})
 			select {
-			case outputCh <- StreamChunk{Type: "error", Content: waitErr.Error()}:
+			case outputCh <- StreamChunk{Type: "error", Content: waitErr.Error(), Events: events}:
 			case <-ctx.Done():
 			}
 		} else {
+			events := append(flushEvents, Event{Version: EventProtocolVersion, Type: TypeDone})
 			select {
-			case outputCh <- StreamChunk{Type: "done"}:
+			case outputCh <- StreamChunk{Type: "done", Events: events}:
 			case <-ctx.Done():
 			}
 		}
@@ -619,6 +658,355 @@ func (a *ACPXAgent) runCommandStream(ctx context.Context, timeout int, args ...s
 	}()
 
 	return outputCh, nil
+}
+
+func newEvent(typ EventType) Event {
+	return Event{Version: EventProtocolVersion, Type: typ}
+}
+
+type protocolState string
+
+const (
+	stateIdle       protocolState = ""
+	stateThinking   protocolState = "thinking"
+	stateToolInput  protocolState = "tool_input"
+	stateToolOutput protocolState = "tool_output"
+	stateOutput     protocolState = "output"
+)
+
+// ProtocolParser converts transcript text into agent-native events.
+type ProtocolParser struct {
+	buf bytes.Buffer
+
+	state protocolState
+
+	thinkingBuf bytes.Buffer
+	outputBuf   bytes.Buffer
+
+	toolName   string
+	toolInput  bytes.Buffer
+	toolOutput bytes.Buffer
+}
+
+// NewProtocolParser creates a parser for agent-native events.
+func NewProtocolParser() *ProtocolParser {
+	return &ProtocolParser{}
+}
+
+// Feed consumes a stream chunk and emits any completed events.
+func (p *ProtocolParser) Feed(chunk string) []Event {
+	chunk = normalizeProtocolChunk(chunk)
+	if chunk == "" {
+		return nil
+	}
+
+	p.buf.WriteString(chunk)
+
+	var events []Event
+	for {
+		line, found := p.readLine()
+		if !found {
+			break
+		}
+		events = append(events, p.processLine(line)...)
+	}
+
+	return events
+}
+
+// Flush emits buffered state as final events.
+func (p *ProtocolParser) Flush() []Event {
+	var events []Event
+
+	if p.buf.Len() > 0 {
+		events = append(events, p.processLine(p.buf.String())...)
+		p.buf.Reset()
+	}
+
+	switch p.state {
+	case stateThinking:
+		events = append(events, p.flushThinking()...)
+	case stateToolInput, stateToolOutput:
+		events = append(events, p.flushTool()...)
+	case stateOutput:
+		events = append(events, p.flushOutput()...)
+	}
+
+	p.state = stateIdle
+	return events
+}
+
+func (p *ProtocolParser) readLine() (string, bool) {
+	data := p.buf.Bytes()
+	idx := bytes.IndexByte(data, '\n')
+	if idx < 0 {
+		return "", false
+	}
+	line := string(data[:idx])
+	p.buf.Next(idx + 1)
+	return line, true
+}
+
+func (p *ProtocolParser) processLine(line string) []Event {
+	var events []Event
+
+	if markerType, content, isMarker := parseProtocolMarker(line); isMarker {
+		switch markerType {
+		case "thinking":
+			events = append(events, p.endActiveBlock()...)
+			events = append(events, newEvent(TypeThinkingStart))
+			p.state = stateThinking
+			if content != "" {
+				p.appendLine(&p.thinkingBuf, content)
+				events = append(events, Event{Version: EventProtocolVersion, Type: TypeThinkingDelta, Content: content})
+			}
+		case "tool":
+			events = append(events, p.processToolMarker(content)...)
+		case "done":
+			events = append(events, p.endActiveBlock()...)
+		default:
+			events = append(events, p.endActiveBlock()...)
+		}
+		return events
+	}
+
+	switch p.state {
+	case stateThinking:
+		if line == "" || startsWithProtocolWhitespace(line) {
+			p.appendLine(&p.thinkingBuf, line)
+			events = append(events, Event{Version: EventProtocolVersion, Type: TypeThinkingDelta, Content: line})
+			return events
+		}
+		events = append(events, p.flushThinking()...)
+		p.state = stateOutput
+		p.appendLine(&p.outputBuf, line)
+		events = append(events, Event{Version: EventProtocolVersion, Type: TypeOutputDelta, Content: line})
+	case stateToolInput:
+		if line == "" || startsWithProtocolWhitespace(line) {
+			p.appendLine(&p.toolInput, line)
+			events = append(events, Event{Version: EventProtocolVersion, Type: TypeToolInput, Name: p.toolName, Input: line})
+			return events
+		}
+		events = append(events, p.flushTool()...)
+		p.state = stateOutput
+		p.appendLine(&p.outputBuf, line)
+		events = append(events, Event{Version: EventProtocolVersion, Type: TypeOutputDelta, Content: line})
+	case stateToolOutput:
+		if line == "" || startsWithProtocolWhitespace(line) {
+			p.appendLine(&p.toolOutput, line)
+			events = append(events, Event{Version: EventProtocolVersion, Type: TypeToolOutput, Name: p.toolName, Output: line})
+			return events
+		}
+		events = append(events, p.flushTool()...)
+		p.state = stateOutput
+		p.appendLine(&p.outputBuf, line)
+		events = append(events, Event{Version: EventProtocolVersion, Type: TypeOutputDelta, Content: line})
+	case stateOutput:
+		p.appendLine(&p.outputBuf, line)
+		events = append(events, Event{Version: EventProtocolVersion, Type: TypeOutputDelta, Content: line})
+	default:
+		if strings.TrimSpace(line) == "" {
+			return nil
+		}
+		p.state = stateOutput
+		p.appendLine(&p.outputBuf, line)
+		events = append(events, Event{Version: EventProtocolVersion, Type: TypeOutputDelta, Content: line})
+	}
+
+	return events
+}
+
+func (p *ProtocolParser) processToolMarker(content string) []Event {
+	content = strings.TrimSpace(content)
+	var events []Event
+
+	switch {
+	case strings.HasSuffix(content, "(pending)"):
+		events = append(events, p.endActiveBlock()...)
+		p.toolName = strings.TrimSpace(strings.TrimSuffix(content, "(pending)"))
+		p.toolInput.Reset()
+		p.toolOutput.Reset()
+		p.state = stateToolInput
+		return append(events, Event{Version: EventProtocolVersion, Type: TypeToolStart, Name: p.toolName})
+	case strings.HasSuffix(content, "(completed)"):
+		if p.state == stateThinking || p.state == stateOutput {
+			events = append(events, p.endActiveBlock()...)
+		}
+		if p.toolName == "" {
+			p.toolName = strings.TrimSpace(strings.TrimSuffix(content, "(completed)"))
+		}
+		p.state = stateToolOutput
+		return events
+	case strings.HasSuffix(content, "(error)"):
+		if p.state == stateThinking || p.state == stateOutput {
+			events = append(events, p.endActiveBlock()...)
+		}
+		name := strings.TrimSpace(strings.TrimSuffix(content, "(error)"))
+		if p.toolName == "" {
+			p.toolName = name
+		}
+		evt := Event{
+			Version: EventProtocolVersion,
+			Type:    TypeError,
+			Name:    p.toolName,
+			Input:   strings.TrimSpace(p.toolInput.String()),
+			Output:  strings.TrimSpace(p.toolOutput.String()),
+			Content: "tool execution failed",
+		}
+		p.resetTool()
+		p.state = stateIdle
+		return append(events, evt)
+	default:
+		events = append(events, p.endActiveBlock()...)
+		return append(events, Event{Version: EventProtocolVersion, Type: TypeToolStart, Name: content})
+	}
+}
+
+func (p *ProtocolParser) endActiveBlock() []Event {
+	switch p.state {
+	case stateThinking:
+		return p.flushThinking()
+	case stateToolInput, stateToolOutput:
+		return p.flushTool()
+	case stateOutput:
+		return p.flushOutput()
+	default:
+		return nil
+	}
+}
+
+func (p *ProtocolParser) flushThinking() []Event {
+	content := trimProtocolBlankLines(p.thinkingBuf.String())
+	p.thinkingBuf.Reset()
+	p.state = stateIdle
+
+	if content == "" {
+		return []Event{newEvent(TypeThinkingEnd)}
+	}
+
+	return []Event{{Version: EventProtocolVersion, Type: TypeThinkingEnd, Content: content}}
+}
+
+func (p *ProtocolParser) flushTool() []Event {
+	if p.toolName == "" {
+		p.resetTool()
+		p.state = stateIdle
+		return nil
+	}
+
+	evt := Event{
+		Version: EventProtocolVersion,
+		Type:    TypeToolEnd,
+		Name:    p.toolName,
+		Input:   strings.TrimSpace(p.toolInput.String()),
+		Output:  strings.TrimSpace(p.toolOutput.String()),
+	}
+	p.resetTool()
+	p.state = stateIdle
+	return []Event{evt}
+}
+
+func (p *ProtocolParser) flushOutput() []Event {
+	content := trimProtocolBlankLines(p.outputBuf.String())
+	p.outputBuf.Reset()
+	p.state = stateIdle
+
+	if content == "" {
+		return nil
+	}
+
+	return []Event{{Version: EventProtocolVersion, Type: TypeOutputFinal, Content: content}}
+}
+
+func (p *ProtocolParser) resetTool() {
+	p.toolName = ""
+	p.toolInput.Reset()
+	p.toolOutput.Reset()
+}
+
+func (p *ProtocolParser) appendLine(buf *bytes.Buffer, line string) {
+	if buf.Len() > 0 {
+		buf.WriteByte('\n')
+	}
+	buf.WriteString(line)
+}
+
+func parseProtocolMarker(line string) (string, string, bool) {
+	if len(line) == 0 || line[0] != '[' {
+		return "", "", false
+	}
+
+	end := strings.IndexByte(line, ']')
+	if end < 1 {
+		return "", "", false
+	}
+
+	markerType := line[1:end]
+	switch markerType {
+	case "thinking", "tool", "done", "client", "acpx":
+	default:
+		return "", "", false
+	}
+
+	return markerType, strings.TrimPrefix(line[end+1:], " "), true
+}
+
+func normalizeProtocolChunk(raw string) string {
+	raw = stripANSI(raw)
+	raw = strings.ReplaceAll(raw, "\r\n", "\n")
+	raw = strings.ReplaceAll(raw, "\r", "\n")
+	return raw
+}
+
+func stripANSI(s string) string {
+	if strings.IndexByte(s, '') < 0 {
+		return s
+	}
+
+	var result bytes.Buffer
+	result.Grow(len(s))
+
+	for i := 0; i < len(s); {
+		if s[i] == '' && i+1 < len(s) && s[i+1] == '[' {
+			i += 2
+			for i < len(s) {
+				c := s[i]
+				i++
+				if c >= 0x40 && c <= 0x7e {
+					break
+				}
+			}
+			continue
+		}
+
+		result.WriteByte(s[i])
+		i++
+	}
+
+	return result.String()
+}
+
+func trimProtocolBlankLines(s string) string {
+	lines := strings.Split(s, "\n")
+	start := 0
+	for start < len(lines) && strings.TrimSpace(lines[start]) == "" {
+		start++
+	}
+
+	end := len(lines)
+	for end > start && strings.TrimSpace(lines[end-1]) == "" {
+		end--
+	}
+
+	return strings.Join(lines[start:end], "\n")
+}
+
+func startsWithProtocolWhitespace(s string) bool {
+	if s == "" {
+		return false
+	}
+	r, _ := utf8.DecodeRuneInString(s)
+	return unicode.IsSpace(r)
 }
 
 // truncate truncates a string to maxLen characters

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -33,6 +33,12 @@ func TestRunCommandStreamReportsErrorAfterContent(t *testing.T) {
 	if chunks[1].Type != "error" {
 		t.Fatalf("expected final error chunk, got %#v", chunks[1])
 	}
+	if len(chunks[1].Events) != 3 {
+		t.Fatalf("expected output_delta, output_final, and error events, got %#v", chunks[1].Events)
+	}
+	if chunks[1].Events[2].Type != TypeError {
+		t.Fatalf("expected terminal error event, got %#v", chunks[1].Events)
+	}
 }
 
 func TestRunCommandStreamPreservesPartialLineWithoutNewline(t *testing.T) {
@@ -52,5 +58,51 @@ func TestRunCommandStreamPreservesPartialLineWithoutNewline(t *testing.T) {
 	}
 	if chunks[1].Type != "done" {
 		t.Fatalf("expected done chunk, got %#v", chunks[1])
+	}
+	if len(chunks[1].Events) != 3 {
+		t.Fatalf("expected output_delta, output_final, and done events, got %#v", chunks[1].Events)
+	}
+	if chunks[1].Events[1].Type != TypeOutputFinal || chunks[1].Events[1].Content != "partial" {
+		t.Fatalf("unexpected output_final event: %#v", chunks[1].Events[1])
+	}
+	if chunks[1].Events[2].Type != TypeDone {
+		t.Fatalf("expected done event, got %#v", chunks[1].Events[2])
+	}
+}
+
+func TestProtocolParserEmitsToolLifecycleAndTerminalEvents(t *testing.T) {
+	parser := NewProtocolParser()
+
+	events := parser.Feed("[thinking] plan\n[tool] Read (pending)\n  path=/tmp\n[tool] Read (completed)\n  ok\nanswer\n")
+	flushed := parser.Flush()
+	events = append(events, flushed...)
+
+	want := []EventType{
+		TypeThinkingStart,
+		TypeThinkingDelta,
+		TypeThinkingEnd,
+		TypeToolStart,
+		TypeToolInput,
+		TypeToolOutput,
+		TypeToolEnd,
+		TypeOutputDelta,
+		TypeOutputFinal,
+	}
+	if len(events) != len(want) {
+		t.Fatalf("expected %d events, got %d: %#v", len(want), len(events), events)
+	}
+	for i, typ := range want {
+		if events[i].Type != typ {
+			t.Fatalf("event %d type = %q, want %q (%#v)", i, events[i].Type, typ, events[i])
+		}
+		if events[i].Version != EventProtocolVersion {
+			t.Fatalf("event %d missing version: %#v", i, events[i])
+		}
+	}
+	if events[6].Name != "Read" || events[6].Input != "path=/tmp" || events[6].Output != "ok" {
+		t.Fatalf("unexpected tool_end payload: %#v", events[6])
+	}
+	if events[8].Content != "answer" {
+		t.Fatalf("unexpected output_final content: %#v", events[8])
 	}
 }

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -57,8 +57,7 @@ type WSConnection struct {
 }
 
 // StreamEvent represents a structured event in the stream.
-// Deprecated: Use event.Event instead.
-type StreamEvent = event.Event
+type StreamEvent = agent.Event
 
 // NewServer creates a new gateway server
 func NewServer(cfg *Config, sessionMgr *session.Manager, agentMgr *agent.Manager) *Server {
@@ -613,10 +612,14 @@ func (s *Server) handleAskStream(conn *WSConnection, req *JSONRPCRequest) {
 	var fullContent strings.Builder
 	var streamErr string
 	parser := event.NewParser()
+	sawNativeEvents := false
 	for chunk := range stream {
 		applyStreamChunk(&fullContent, &streamErr, chunk)
+		if len(chunk.Events) > 0 {
+			sawNativeEvents = true
+		}
 
-		for _, evt := range buildStructuredEvents(parser, chunk, false) {
+		for _, evt := range buildStructuredEvents(parser, chunk) {
 			if err := conn.SendJSON(newEventNotification(req.ID, evt)); err != nil {
 				log.Printf("[gateway] WebSocket send failed: %v, cancelling stream", err)
 				cancel()
@@ -642,11 +645,13 @@ func (s *Server) handleAskStream(conn *WSConnection, req *JSONRPCRequest) {
 		}
 	}
 
-	for _, evt := range buildStructuredEvents(parser, agent.StreamChunk{}, true) {
-		if err := conn.SendJSON(newEventNotification(req.ID, evt)); err != nil {
-			log.Printf("[gateway] WebSocket send failed: %v, cancelling stream", err)
-			cancel()
-			return
+	if !sawNativeEvents {
+		for _, evt := range flushStructuredEvents(parser, streamErr == "") {
+			if err := conn.SendJSON(newEventNotification(req.ID, evt)); err != nil {
+				log.Printf("[gateway] WebSocket send failed: %v, cancelling stream", err)
+				cancel()
+				return
+			}
 		}
 	}
 
@@ -683,30 +688,64 @@ func applyStreamChunk(fullContent *strings.Builder, streamErr *string, chunk age
 	}
 }
 
-func buildStructuredEvents(parser *event.Parser, chunk agent.StreamChunk, flush bool) []event.Event {
-	var events []event.Event
+func buildStructuredEvents(parser *event.Parser, chunk agent.StreamChunk) []agent.Event {
+	if len(chunk.Events) > 0 {
+		return append([]agent.Event(nil), chunk.Events...)
+	}
 
+	var events []agent.Event
 	if chunk.Type == "content" {
-		events = append(events, parser.Feed(chunk.Content)...)
+		events = append(events, convertLegacyEvents(parser.Feed(chunk.Content))...)
 	}
-
 	if chunk.Type == "error" {
-		events = append(events, event.Event{
-			Type:    event.TypeError,
-			Content: chunk.Content,
-		})
+		events = append(events, agent.Event{Version: agent.EventProtocolVersion, Type: agent.TypeError, Content: chunk.Content})
 	}
-
-	if flush {
-		events = append(events, parser.Flush()...)
-	}
-
 	return events
 }
 
-func newEventNotification(id string, evt event.Event) JSONRPCRequest {
+func flushStructuredEvents(parser *event.Parser, includeDone bool) []agent.Event {
+	events := convertLegacyEvents(parser.Flush())
+	if includeDone {
+		events = append(events, agent.Event{Version: agent.EventProtocolVersion, Type: agent.TypeDone})
+	}
+	return events
+}
+
+func convertLegacyEvents(legacy []event.Event) []agent.Event {
+	var events []agent.Event
+	for _, evt := range legacy {
+		switch evt.Type {
+		case event.TypeThinking:
+			events = append(events,
+				agent.Event{Version: agent.EventProtocolVersion, Type: agent.TypeThinkingStart},
+				agent.Event{Version: agent.EventProtocolVersion, Type: agent.TypeThinkingDelta, Content: evt.Content},
+				agent.Event{Version: agent.EventProtocolVersion, Type: agent.TypeThinkingEnd, Content: evt.Content},
+			)
+		case event.TypeToolStart:
+			events = append(events, agent.Event{Version: agent.EventProtocolVersion, Type: agent.TypeToolStart, Name: evt.Name})
+		case event.TypeToolInput:
+			events = append(events, agent.Event{Version: agent.EventProtocolVersion, Type: agent.TypeToolInput, Name: evt.Name, Input: evt.Input})
+		case event.TypeToolEnd:
+			if evt.Input != "" {
+				events = append(events, agent.Event{Version: agent.EventProtocolVersion, Type: agent.TypeToolInput, Name: evt.Name, Input: evt.Input})
+			}
+			if evt.Output != "" {
+				events = append(events, agent.Event{Version: agent.EventProtocolVersion, Type: agent.TypeToolOutput, Name: evt.Name, Output: evt.Output})
+			}
+			events = append(events, agent.Event{Version: agent.EventProtocolVersion, Type: agent.TypeToolEnd, Name: evt.Name, Input: evt.Input, Output: evt.Output})
+		case event.TypeToolError, event.TypeError:
+			events = append(events, agent.Event{Version: agent.EventProtocolVersion, Type: agent.TypeError, Content: evt.Content, Name: evt.Name, Input: evt.Input, Output: evt.Output})
+		case event.TypeOutput:
+			events = append(events, agent.Event{Version: agent.EventProtocolVersion, Type: agent.TypeOutputFinal, Content: evt.Content})
+		}
+	}
+	return events
+}
+
+func newEventNotification(id string, evt agent.Event) JSONRPCRequest {
 	params := map[string]interface{}{
 		"id":      id,
+		"version": evt.Version,
 		"type":    string(evt.Type),
 		"content": evt.Content,
 	}

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -38,71 +38,60 @@ func TestApplyStreamChunkCapturesErrorSeparately(t *testing.T) {
 	}
 }
 
-func TestBuildStructuredEventsFromTranscriptChunks(t *testing.T) {
+func TestBuildStructuredEventsPrefersNativeAgentEvents(t *testing.T) {
 	parser := event.NewParser()
-
-	events := buildStructuredEvents(parser, agent.StreamChunk{Type: "content", Content: "[thinking] hello\nworld\n"}, false)
-	if len(events) != 1 {
-		t.Fatalf("expected one structured event, got %#v", events)
-	}
-	if events[0].Type != event.TypeThinking || events[0].Content != "hello" {
-		t.Fatalf("unexpected thinking event: %#v", events[0])
+	chunk := agent.StreamChunk{
+		Type:    "content",
+		Content: "ignored transcript",
+		Events:  []agent.Event{{Version: agent.EventProtocolVersion, Type: agent.TypeOutputDelta, Content: "hello"}},
 	}
 
-	events = buildStructuredEvents(parser, agent.StreamChunk{}, true)
+	events := buildStructuredEvents(parser, chunk)
 	if len(events) != 1 {
-		t.Fatalf("expected one flushed event, got %#v", events)
+		t.Fatalf("expected one native event, got %#v", events)
 	}
-	if events[0].Type != event.TypeOutput || events[0].Content != "world" {
-		t.Fatalf("unexpected flushed output event: %#v", events[0])
+	if events[0].Type != agent.TypeOutputDelta || events[0].Content != "hello" {
+		t.Fatalf("unexpected native event: %#v", events[0])
 	}
 }
 
-func TestBuildStructuredEventsIncludesErrors(t *testing.T) {
+func TestBuildStructuredEventsFallsBackToTranscriptParser(t *testing.T) {
 	parser := event.NewParser()
 
-	events := buildStructuredEvents(parser, agent.StreamChunk{Type: "error", Content: "exit status 5"}, false)
+	events := buildStructuredEvents(parser, agent.StreamChunk{Type: "content", Content: "[thinking] hello\nworld\n"})
+	if len(events) != 3 {
+		t.Fatalf("expected three fallback events, got %#v", events)
+	}
+	if events[0].Type != agent.TypeThinkingStart {
+		t.Fatalf("expected thinking_start, got %#v", events[0])
+	}
+	if events[1].Type != agent.TypeThinkingDelta || events[1].Content != "hello" {
+		t.Fatalf("unexpected thinking_delta event: %#v", events[1])
+	}
+	if events[2].Type != agent.TypeThinkingEnd || events[2].Content != "hello" {
+		t.Fatalf("unexpected thinking_end event: %#v", events[2])
+	}
+
+	flushed := flushStructuredEvents(parser, true)
+	if len(flushed) != 2 {
+		t.Fatalf("expected output_final and done, got %#v", flushed)
+	}
+	if flushed[0].Type != agent.TypeOutputFinal || flushed[0].Content != "world" {
+		t.Fatalf("unexpected flushed output event: %#v", flushed[0])
+	}
+	if flushed[1].Type != agent.TypeDone {
+		t.Fatalf("expected done event, got %#v", flushed[1])
+	}
+}
+
+func TestBuildStructuredEventsIncludesFallbackErrors(t *testing.T) {
+	parser := event.NewParser()
+
+	events := buildStructuredEvents(parser, agent.StreamChunk{Type: "error", Content: "exit status 5"})
 	if len(events) != 1 {
 		t.Fatalf("expected one error event, got %#v", events)
 	}
-	if events[0].Type != event.TypeError || events[0].Content != "exit status 5" {
+	if events[0].Type != agent.TypeError || events[0].Content != "exit status 5" {
 		t.Fatalf("unexpected error event: %#v", events[0])
-	}
-}
-
-func TestBuildStructuredEventsParsesToolLifecycle(t *testing.T) {
-	parser := event.NewParser()
-
-	// Tool start
-	events := buildStructuredEvents(parser, agent.StreamChunk{Type: "content", Content: "[tool] Read (pending)\n"}, false)
-	if len(events) != 1 || events[0].Type != event.TypeToolStart {
-		t.Fatalf("expected tool_start event, got %#v", events)
-	}
-	if events[0].Name != "Read" {
-		t.Fatalf("expected tool name 'Read', got %q", events[0].Name)
-	}
-
-	// Tool input
-	events = buildStructuredEvents(parser, agent.StreamChunk{Type: "content", Content: "  input: {\"path\": \"/tmp\"}\n"}, false)
-	if len(events) != 0 {
-		t.Fatalf("expected no events for tool input, got %#v", events)
-	}
-
-	// Tool end
-	events = buildStructuredEvents(parser, agent.StreamChunk{Type: "content", Content: "[tool] Read (completed)\n  output: hello\n"}, false)
-	// After completion, we collect output, then flush
-	events = append(events, buildStructuredEvents(parser, agent.StreamChunk{}, true)...)
-
-	var foundToolEnd bool
-	for _, e := range events {
-		if e.Type == event.TypeToolEnd {
-			foundToolEnd = true
-			if e.Name != "Read" {
-				t.Errorf("expected tool name 'Read', got %q", e.Name)
-			}
-		}
-	}
-	if !foundToolEnd {
-		t.Errorf("expected tool_end event, got %#v", events)
 	}
 }


### PR DESCRIPTION
## Summary

- Add typed EventType constants (thinking_*, tool_*, output_*, error, done)
- Define Event struct with version, type, content, name, input, output fields
- Add ProtocolParser for incremental event parsing from agent output
- Update StreamChunk to carry native Events alongside content
- Update gateway to prefer native events over transcript inference
- Add comprehensive tests for event ordering and lifecycle

## Changes

| File | Changes |
|------|---------|
| `internal/agent/agent.go` | +400 lines - Event types, ProtocolParser, native event emission |
| `internal/agent/agent_test.go` | +52 lines - Parser tests |
| `internal/gateway/server.go` | +77 lines - Native event handling |
| `internal/gateway/server_test.go` | Refactored tests |
| `cmd/imclaw-cli/main.go` | +18 lines - CLI event handling |
| `cmd/imclaw-cli/main_test.go` | +9 lines - CLI tests |

## Test plan

- [x] All existing tests pass
- [x] New tests for event ordering and lifecycle
- [x] Parser correctly emits events incrementally
- [x] Gateway prefers native events over transcript inference
- [x] Backward compatibility maintained

Closes #15